### PR TITLE
basic認証実装（途中）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 group :development do
   gem 'rubocop', require: false
+  gem 'rails-erd'
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    choice (0.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
@@ -155,6 +156,11 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
+    rails-erd (1.6.1)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      choice (~> 0.2.0)
+      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
     railties (6.0.3.7)
@@ -184,6 +190,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.7.0)
       parser (>= 3.0.1.1)
+    ruby-graphviz (1.2.5)
+      rexml
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.2)
       ffi (~> 1.12)
@@ -262,6 +270,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-erd
   rubocop
   sass-rails (~> 5)
   selenium-webdriver

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+
+  private
+  def basic_auth
+    authenticate_orrequest_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"], && password == ENV[BASIC_AUTH_PASSWORD]
+  end
 end
+

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,9 @@
 class ApplicationController < ActionController::Base
 
-  private
-  def basic_auth
-    authenticate_orrequest_with_http_basic do |username, password|
-      username == ENV["BASIC_AUTH_USER"], && password == ENV[BASIC_AUTH_PASSWORD]
-  end
+  # private
+  # def basic_auth
+  #   authenticate_orrequest_with_http_basic do |username, password|
+  #     username == ENV["BASIC_AUTH_USER"], && password == ENV[BASIC_AUTH_PASSWORD]
+  # end
 end
 


### PR DESCRIPTION
basic認証を実装
・前カリキュラムで実装したログインシェルを引用

デプロイは
記述のindexに遷移する機能までは実装していないが先にherokuにデプロイする準備だけ終わらせた。